### PR TITLE
allows card to not have a title

### DIFF
--- a/src/ts/components/card/Card.tsx
+++ b/src/ts/components/card/Card.tsx
@@ -5,7 +5,12 @@ import {
     DashLoadingState,
 } from "../../types";
 import { Card as AntCard, CardProps } from "antd";
-import { parseChildrenToArray, getComponentType } from "../../utilities";
+import {
+    parseChildrenToArray,
+    getComponentType,
+    isStringWithCharacters,
+} from "../../utilities";
+import "./card.less";
 
 type Props = {
     /**
@@ -47,7 +52,7 @@ type Props = {
 } & DashComponentProps &
     StyledComponentProps;
 
-const omittedClasses = ["CardAction", "CardExtra"];
+const omittedClasses = ["CardAction", "CardExtra", "CardTitle"];
 
 /**
  * Simple rectangular container.
@@ -60,6 +65,7 @@ const Card = (props: Props) => {
         class_name,
         head_style,
         loading_state,
+        title,
         setProps,
         ...otherProps
     } = props;
@@ -97,8 +103,11 @@ const Card = (props: Props) => {
             actions={actionItems}
             activeTabKey={active_tab_key}
             bodyStyle={body_style}
-            className={class_name}
+            className={`${class_name || ""} ${
+                !isStringWithCharacters(title) ? "hide-title" : ""
+            }`}
             extra={extraItems}
+            title={title}
             headStyle={head_style}
             loading={(loading_state && loading_state.is_loading) || undefined}
             onTabChange={onTabChange}

--- a/src/ts/components/card/card.less
+++ b/src/ts/components/card/card.less
@@ -1,0 +1,8 @@
+.ant-card {
+  &.hide-title {
+    .ant-card-head {
+      height: 0;
+      min-height: 0;
+    }
+  }
+}

--- a/src/ts/utilities.ts
+++ b/src/ts/utilities.ts
@@ -5,6 +5,14 @@ function isNodeArray<T>(node: T | T[]): node is T[] {
     return Array.isArray(node);
 }
 
+function isString(string: string) {
+    return typeof string === "string";
+}
+
+export function isStringWithCharacters(string: string) {
+    return isString(string) && string.length > 0;
+}
+
 export function parseChildrenToArray<T>(children?: T | T[]): T[] {
     if (children) {
         if (!isNodeArray(children)) {


### PR DESCRIPTION
This is quite hacky, but this is the only way I can find to not display the card header if no title is passed as a property. For some reason this works fine when importing directly from antd, but when importing from the wrapper component, even if a title is not passed, the component still shows the card title section.

Feel free to play with this if you can think of a better way!